### PR TITLE
Fix compatibility with wookie & uv branch of cl-async.

### DIFF
--- a/src/driver.lisp
+++ b/src/driver.lisp
@@ -48,6 +48,9 @@
                                     :sec-websocket-key
                                     :sec-websocket-version
                                     :upgrade))
+                    :headers (let ((table (make-hash-table :test #'equal)))
+                               (alexandria:doplist (k v headers table)
+                                 (setf (gethash (string-downcase k) table) v)))
                     :request-method (request-method req))))
       (apply #'make-server-for-clack
              env

--- a/src/driver/base.lisp
+++ b/src/driver/base.lisp
@@ -186,14 +186,7 @@
   (let ((socket (socket driver)))
     (etypecase socket
       (as:socket
-       (as:delay
-        (lambda ()
-          (let* ((bev-data (as::deref-data-from-pointer (as::socket-c socket)))
-                 (socket-data-pointer (getf bev-data :data-pointer)))
-            (as::save-callbacks socket-data-pointer
-                                (list :read-cb (lambda (socket data)
-                                                 (declare (ignore socket))
-                                                 (funcall callback data))))))))
+       (setf (getf (as:socket-data socket) :parser) callback))
       (iolib:socket
        (iolib:set-io-handler (event-base driver)
                              (iolib:socket-os-fd socket)


### PR DESCRIPTION
websocket-driver didn't work with recent wookie and cl-async.
Fixed it by adding missing :headers to driver env & using less invasive method of snatching the socket from wookie.
