### PR TITLE
Fix parsing of extended length field.

### DIFF
--- a/src/driver/hybi.lisp
+++ b/src/driver/hybi.lisp
@@ -328,7 +328,9 @@
                   (setq length-size (if (= length 126) 2 8))
                   (setf (stage driver) 2))))
              (parse-extended-length (buffer)
-               (setq length (length buffer))
+               (setq length (aref buffer 0))
+               (loop for i from 1 below (length buffer)
+                     do (setq length (+ (ash length 8) (aref buffer i))))
 
                (unless (or (find opcode *fragmented-opcodes* :test #'=)
                            (<= length 125))


### PR DESCRIPTION
The extended length field is either 16 or 64-bit integer value with network byte order
https://tools.ietf.org/html/rfc6455#page-29

Without this patch, the following code causes the driver to fail (recent Chrome):
```javascript
var ws = new WebSocket("ws://localhost:8080/livereload");
ws.onopen = function() {
  ws.send('XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX');
}
```