### PR TITLE
Make 'parse' thread safe.

### DIFF
--- a/websocket-driver-base.asd
+++ b/websocket-driver-base.asd
@@ -12,7 +12,8 @@
                :event-emitter
                :ironclad
                :cl-base64
-               :split-sequence)
+               :split-sequence
+               :bordeaux-threads)
   :components ((:module "src"
                 :components
                 ((:file "driver" :depends-on ("ws/base"))


### PR DESCRIPTION
'parse' function made by make-parser is stateful, so it should be locked.
