### PR TITLE
Should close-connection be called when closing the connection?

### DIFF
--- a/src/driver.lisp
+++ b/src/driver.lisp
@@ -58,6 +58,6 @@
 (defun websocket-p (env)
   (let ((headers (getf env :headers)))
     (and (eq (getf env :request-method) :get)
-         (string-equal (gethash "connection" headers "") "upgrade")
+         (search "upgrade"  (gethash "connection" headers "") :test 'equalp)
          (string-equal (gethash "upgrade" headers "") "websocket")
          (eql (gethash "sec-websocket-version" headers) 13))))

--- a/src/ws/base.lisp
+++ b/src/ws/base.lisp
@@ -95,7 +95,7 @@
                      (lambda (payload)
                        (let ((callback (gethash payload (ping-callbacks ws))))
                          (when callback
-                           (remhash payload (ping-callbacks ws)) 
+                           (remhash payload (ping-callbacks ws))
                            (funcall callback))))
                      :close-callback
                      (lambda (data &key code)
@@ -139,9 +139,9 @@
     (return-from send
       (enqueue ws (cons data args))))
 
-  (when (eq (ready-state ws) :closing)
+  (when (and (eq (ready-state ws) :closing) callback)
     (funcall callback))
-  
+
   (unless (eq (ready-state ws) :open)
     (return-from send nil))
 


### PR DESCRIPTION
This enables the user to do the following from the websocket handler
``` cl
      (on :close ws
	  (lambda (code reason)
	    (log:info 'message-log "Closed by browser" reason code)))
```
