### PR TITLE
SSL: Add a way to skip local cert verification on connecting

### DIFF
--- a/src/ws/base.lisp
+++ b/src/ws/base.lisp
@@ -126,7 +126,7 @@
             (:closing    2)
             (:closed     3)))))
 
-(defgeneric start-connection (ws))
+(defgeneric start-connection (ws &key &allow-other-keys))
 
 (defgeneric parse (ws data &key start end)
   (:method (ws data &key start end)

--- a/src/ws/client.lisp
+++ b/src/ws/client.lisp
@@ -109,7 +109,7 @@
 
      eof)))
 
-(defmethod start-connection ((client client))
+(defmethod start-connection ((client client) &key (verify t))
   (unless (eq (ready-state client) :connecting)
     (return-from start-connection))
 
@@ -164,12 +164,15 @@
                        (progn
                          (cl+ssl:ensure-initialized)
                          (setf (cl+ssl:ssl-check-verify-p) t)
-                         (let ((ctx (cl+ssl:make-context :verify-mode cl+ssl:+ssl-verify-peer+
+                         (let ((ctx (cl+ssl:make-context :verify-mode (if verify
+                                                                          cl+ssl:+ssl-verify-peer+
+                                                                          cl+ssl:+ssl-verify-none+)
                                                          :verify-location :default)))
                            ;; TODO: certificate files
                            (cl+ssl:with-global-context (ctx :auto-free-p t)
                              (cl+ssl:make-ssl-client-stream stream
-                                                            :hostname (uri-host uri)))))
+                                                            :hostname (uri-host uri)
+                                                            :verify (if verify :optional nil)))))
                        stream)))
 
       (setf (socket client) stream)

--- a/src/ws/server.lisp
+++ b/src/ws/server.lisp
@@ -60,7 +60,7 @@
          (error "Unsupported WebSocket version: ~S" ws-version)))))
   (setf (version server) "hybi-13"))
 
-(defmethod start-connection ((server server))
+(defmethod start-connection ((server server) &key)
   (unless (eq (ready-state server) :connecting)
       (return-from start-connection))
 


### PR DESCRIPTION
Sometimes the certificate verification is undesired and causes issues - notably this one #19.

Usage:

```lisp
(wsd:start-connection my-client :verify nil)
```

Backwards compatibility should be preserved.