### PR TITLE
Fixed inconsistent params on "close" event

### DIFF
--- a/src/ws/base.lisp
+++ b/src/ws/base.lisp
@@ -170,15 +170,15 @@
   (case (ready-state ws)
     (:connecting
      (setf (ready-state ws) :closed)
-     (emit :close ws code reason)
+     (emit :close ws :code code :reason reason)
      t)
     (:closing
      (call-next-method)
-     (emit :close ws code reason))
+     (emit :close ws :code code :reason reason))
     (:open
      (call-next-method))
     (:closing
-     (emit :close ws code reason))
+     (emit :close ws :code code :reason reason))
     (otherwise nil)))
 
 (defgeneric open-connection (ws)

--- a/src/ws/base.lisp
+++ b/src/ws/base.lisp
@@ -170,11 +170,11 @@
   (case (ready-state ws)
     (:connecting
      (setf (ready-state ws) :closed)
-     (emit :close ws :code code :reason reason)
+     (emit :close ws code reason)
      t)
     (:closing
      (call-next-method)
-     (emit :close ws :code code :reason reason))
+     (emit :close ws code reason))
     (:open
      (call-next-method))
     (:closing


### PR DESCRIPTION
:close handler arity are 2, not 4.