### PR TITLE
Replace ironclad with babel and sha1

### DIFF
--- a/src/util.lisp
+++ b/src/util.lisp
@@ -3,11 +3,6 @@
   (:use :cl)
   (:import-from :split-sequence
                 #:split-sequence)
-  (:import-from :cl-base64
-                #:usb8-array-to-base64-string)
-  (:import-from :ironclad
-                :digest-sequence
-                :ascii-string-to-byte-array)
   (:export #:split-by-comma
            #:generate-accept))
 (in-package :websocket-driver.util)
@@ -23,7 +18,4 @@
 (defun generate-accept (key)
   (declare (optimize (speed 3) (safety 0))
            (type simple-string key))
-  (base64:usb8-array-to-base64-string
-   (ironclad:digest-sequence :sha1
-                             (ironclad:ascii-string-to-byte-array
-                              (concatenate 'string key +guid+)))))
+  (sha1:sha1-base64 (concatenate 'string key +guid+)))

--- a/src/ws/client.lisp
+++ b/src/ws/client.lisp
@@ -19,8 +19,6 @@
                 #:usb8-array-to-base64-string)
   (:import-from :trivial-utf-8
                 #:string-to-utf-8-bytes)
-  (:import-from :ironclad
-                #:ascii-string-to-byte-array)
   (:import-from :quri
                 #:uri
                 #:uri-scheme
@@ -218,9 +216,9 @@
        (labels ((octets (data)
                   (fast-write-sequence data buffer))
                 (ascii-string (data)
-                  (octets (ascii-string-to-byte-array data)))
+                  (octets (babel:string-to-octets data)))
                 (crlf ()
-                  (octets #.(ascii-string-to-byte-array (format nil "~C~C" #\Return #\Newline)))))
+                  (octets #.(babel:string-to-octets (format nil "~C~C" #\Return #\Newline)))))
          (ascii-string
           (format nil "GET ~:[/~;~:*~A~]~:[~;~:*?~A~] HTTP/1.1~C~C"
                   (quri:uri-path uri)
@@ -231,7 +229,7 @@
                   (quri:uri-authority uri)
                   #\Return #\Newline))
          (octets
-          #.(ascii-string-to-byte-array
+          #.(babel:string-to-octets
              (with-output-to-string (s)
                (format s "Upgrade: websocket~C~C" #\Return #\Newline)
                (format s "Connection: Upgrade~C~C" #\Return #\Newline))))
@@ -240,7 +238,7 @@
                   (key client)
                   #\Return #\Newline))
          (octets
-          #.(ascii-string-to-byte-array
+          #.(babel:string-to-octets
              (format nil "Sec-WebSocket-Version: 13~C~C" #\Return #\Newline)))
          (when (accept-protocols client)
            (ascii-string
@@ -252,7 +250,7 @@
                do (ascii-string
                    (string-capitalize name))
                   (octets
-                   #.(ascii-string-to-byte-array ": "))
+                   #.(babel:string-to-octets ": "))
                   (ascii-string value)
                   (crlf))
 

--- a/src/ws/server.lisp
+++ b/src/ws/server.lisp
@@ -19,8 +19,6 @@
                 #:with-fast-output
                 #:fast-write-sequence
                 #:fast-write-byte)
-  (:import-from :ironclad
-                #:ascii-string-to-byte-array)
   (:import-from :trivial-utf-8
                 #:string-to-utf-8-bytes)
   (:export #:server))
@@ -119,11 +117,11 @@
     (labels ((octets (data)
                (write-sequence-to-socket-buffer socket data))
              (ascii-string (data)
-               (octets (ascii-string-to-byte-array data)))
+               (octets (babel:string-to-octets data)))
              (crlf ()
-               (octets #.(ascii-string-to-byte-array (format nil "~C~C" #\Return #\Newline)))))
+               (octets #.(babel:string-to-octets (format nil "~C~C" #\Return #\Newline)))))
       (octets
-       #.(ascii-string-to-byte-array
+       #.(babel:string-to-octets
           (with-output-to-string (s)
             (format s "HTTP/1.1 101 Switching Protocols~C~C" #\Return #\Newline)
             (format s "Upgrade: websocket~C~C" #\Return #\Newline)
@@ -136,7 +134,7 @@
       (let ((protocol (protocol server)))
         (when protocol
           (octets
-           #.(ascii-string-to-byte-array "Sec-WebSocket-Protocol: "))
+           #.(babel:string-to-octets "Sec-WebSocket-Protocol: "))
           (ascii-string protocol)
           (crlf)))
 
@@ -144,7 +142,7 @@
             do (ascii-string
                 (string-capitalize name))
                (octets
-                #.(ascii-string-to-byte-array ": "))
+                #.(babel:string-to-octets ": "))
                (ascii-string value)
                (crlf))
 

--- a/websocket-driver-base.asd
+++ b/websocket-driver-base.asd
@@ -10,8 +10,7 @@
   :depends-on (:fast-websocket
                :fast-io
                :event-emitter
-               :ironclad
-               :cl-base64
+               :sha1
                :split-sequence
                :bordeaux-threads)
   :components ((:module "src"

--- a/websocket-driver-client.asd
+++ b/websocket-driver-client.asd
@@ -15,7 +15,7 @@
                :fast-http
                :cl-base64
                :trivial-utf-8
-               :ironclad
+               :babel
                :quri)
   :components ((:module "src"
                 :components

--- a/websocket-driver-server.asd
+++ b/websocket-driver-server.asd
@@ -11,7 +11,7 @@
                :fast-websocket
                :fast-io
                :clack-socket
-               :ironclad
+               :babel
                :trivial-utf-8)
   :components ((:module "src"
                 :components


### PR DESCRIPTION
Ironclad is a huge library with huge building problems on ECL. websocket-driver only uses it for two functions. One of them is available from babel which is already included through fast-http, the other one is sha1 hash. There's a library in quicklisp for it but there's a collision with another base64 package.

I've made a PR to the sha1 library ( https://github.com/massung/sha1 ) to use cl-base64 too. You can accept this PR right after my sha1 PR is accepted.