### PR TITLE
Remove trivial-utf-8 as a dependency

### DIFF
--- a/src/ws/client.lisp
+++ b/src/ws/client.lisp
@@ -17,8 +17,6 @@
                 #:http-status)
   (:import-from :cl-base64
                 #:usb8-array-to-base64-string)
-  (:import-from :trivial-utf-8
-                #:string-to-utf-8-bytes)
   (:import-from :ironclad
                 #:ascii-string-to-byte-array)
   (:import-from :quri

--- a/src/ws/server.lisp
+++ b/src/ws/server.lisp
@@ -21,8 +21,6 @@
                 #:fast-write-byte)
   (:import-from :ironclad
                 #:ascii-string-to-byte-array)
-  (:import-from :trivial-utf-8
-                #:string-to-utf-8-bytes)
   (:export #:server))
 (in-package :websocket-driver.ws.server)
 

--- a/websocket-driver-client.asd
+++ b/websocket-driver-client.asd
@@ -14,7 +14,6 @@
                :fast-websocket
                :fast-http
                :cl-base64
-               :trivial-utf-8
                :ironclad
                :quri)
   :components ((:module "src"

--- a/websocket-driver-server.asd
+++ b/websocket-driver-server.asd
@@ -11,8 +11,7 @@
                :fast-websocket
                :fast-io
                :clack-socket
-               :ironclad
-               :trivial-utf-8)
+               :ironclad)
   :components ((:module "src"
                 :components
                 ((:file "server" :depends-on ("ws/server"))


### PR DESCRIPTION
Since no code is using string-to-utf-8-bytes or utf-8-bytes-to-string
any more, trivial-utf-8 can be taken off the dependency list.