### PR TITLE
Replace ironclad dependency with babel and sha1

### DIFF
--- a/src/util.lisp
+++ b/src/util.lisp
@@ -4,10 +4,9 @@
   (:import-from :split-sequence
                 #:split-sequence)
   (:import-from :cl-base64
-                #:usb8-array-to-base64-string)
-  (:import-from :ironclad
-                :digest-sequence
-                :ascii-string-to-byte-array)
+                #:string-to-base64-string)
+  (:import-from :sha1
+                #:sha1-base64)
   (:export #:split-by-comma
            #:generate-accept))
 (in-package :websocket-driver.util)
@@ -23,7 +22,5 @@
 (defun generate-accept (key)
   (declare (optimize (speed 3) (safety 0))
            (type simple-string key))
-  (base64:usb8-array-to-base64-string
-   (ironclad:digest-sequence :sha1
-                             (ironclad:ascii-string-to-byte-array
-                              (concatenate 'string key +guid+)))))
+  (sha1:sha1-base64 (concatenate 'string key +guid+)
+                    #'string-to-base64-string))

--- a/src/ws/client.lisp
+++ b/src/ws/client.lisp
@@ -17,8 +17,8 @@
                 #:http-status)
   (:import-from :cl-base64
                 #:usb8-array-to-base64-string)
-  (:import-from :ironclad
-                #:ascii-string-to-byte-array)
+  (:import-from :babel
+                #:string-to-octets)
   (:import-from :quri
                 #:uri
                 #:uri-scheme
@@ -216,9 +216,10 @@
        (labels ((octets (data)
                   (fast-write-sequence data buffer))
                 (ascii-string (data)
-                  (octets (ascii-string-to-byte-array data)))
+                  (octets (string-to-octets data :encoding :ascii)))
                 (crlf ()
-                  (octets #.(ascii-string-to-byte-array (format nil "~C~C" #\Return #\Newline)))))
+                  (octets #.(string-to-octets (format nil "~C~C" #\Return #\Newline)
+                                              :encoding :ascii))))
          (ascii-string
           (format nil "GET ~:[/~;~:*~A~]~:[~;~:*?~A~] HTTP/1.1~C~C"
                   (quri:uri-path uri)
@@ -229,17 +230,19 @@
                   (quri:uri-authority uri)
                   #\Return #\Newline))
          (octets
-          #.(ascii-string-to-byte-array
+          #.(string-to-octets
              (with-output-to-string (s)
                (format s "Upgrade: websocket~C~C" #\Return #\Newline)
-               (format s "Connection: Upgrade~C~C" #\Return #\Newline))))
+               (format s "Connection: Upgrade~C~C" #\Return #\Newline))
+             :encoding :ascii))
          (ascii-string
           (format nil "Sec-WebSocket-Key: ~A~C~C"
                   (key client)
                   #\Return #\Newline))
          (octets
-          #.(ascii-string-to-byte-array
-             (format nil "Sec-WebSocket-Version: 13~C~C" #\Return #\Newline)))
+          #.(string-to-octets
+             (format nil "Sec-WebSocket-Version: 13~C~C" #\Return #\Newline)
+             :encoding :ascii))
          (when (accept-protocols client)
            (ascii-string
             (format nil "Sec-WebSocket-Protocol: ~{~A~^, ~}~C~C"
@@ -250,7 +253,7 @@
                do (ascii-string
                    (string-capitalize name))
                   (octets
-                   #.(ascii-string-to-byte-array ": "))
+                   #.(string-to-octets ": " :encoding :ascii))
                   (ascii-string value)
                   (crlf))
 

--- a/src/ws/server.lisp
+++ b/src/ws/server.lisp
@@ -19,8 +19,8 @@
                 #:with-fast-output
                 #:fast-write-sequence
                 #:fast-write-byte)
-  (:import-from :ironclad
-                #:ascii-string-to-byte-array)
+  (:import-from :babel
+                #:string-to-octets)
   (:export #:server))
 (in-package :websocket-driver.ws.server)
 
@@ -117,16 +117,18 @@
     (labels ((octets (data)
                (write-sequence-to-socket-buffer socket data))
              (ascii-string (data)
-               (octets (ascii-string-to-byte-array data)))
+               (octets (string-to-octets data :encoding :ascii)))
              (crlf ()
-               (octets #.(ascii-string-to-byte-array (format nil "~C~C" #\Return #\Newline)))))
+               (octets #.(string-to-octets (format nil "~C~C" #\Return #\Newline)
+                                           :encoding :ascii))))
       (octets
-       #.(ascii-string-to-byte-array
+       #.(string-to-octets
           (with-output-to-string (s)
             (format s "HTTP/1.1 101 Switching Protocols~C~C" #\Return #\Newline)
             (format s "Upgrade: websocket~C~C" #\Return #\Newline)
             (format s "Connection: Upgrade~C~C" #\Return #\Newline)
-            (format s "Sec-WebSocket-Accept: "))))
+            (format s "Sec-WebSocket-Accept: "))
+          :encoding :ascii))
       (ascii-string
        (generate-accept sec-key))
       (crlf)
@@ -134,7 +136,8 @@
       (let ((protocol (protocol server)))
         (when protocol
           (octets
-           #.(ascii-string-to-byte-array "Sec-WebSocket-Protocol: "))
+           #.(string-to-octets "Sec-WebSocket-Protocol: "
+                               :encoding :ascii))
           (ascii-string protocol)
           (crlf)))
 
@@ -142,7 +145,7 @@
             do (ascii-string
                 (string-capitalize name))
                (octets
-                #.(ascii-string-to-byte-array ": "))
+                #.(string-to-octets ": " :encoding :ascii))
                (ascii-string value)
                (crlf))
 

--- a/websocket-driver-base.asd
+++ b/websocket-driver-base.asd
@@ -10,7 +10,7 @@
   :depends-on (:fast-websocket
                :fast-io
                :event-emitter
-               :ironclad
+               :sha1
                :cl-base64
                :split-sequence
                :bordeaux-threads)

--- a/websocket-driver-client.asd
+++ b/websocket-driver-client.asd
@@ -14,7 +14,7 @@
                :fast-websocket
                :fast-http
                :cl-base64
-               :ironclad
+               :babel
                :quri)
   :components ((:module "src"
                 :components

--- a/websocket-driver-server.asd
+++ b/websocket-driver-server.asd
@@ -11,7 +11,7 @@
                :fast-websocket
                :fast-io
                :clack-socket
-               :ironclad)
+               :babel)
   :components ((:module "src"
                 :components
                 ((:file "server" :depends-on ("ws/server"))


### PR DESCRIPTION
Ironclad is a meaty dependency. This system takes the longest time on my
computer to compile my web application, and I've read comments online
that it adds ~19MB RAM usage in a lisp image. `websocket-driver` is
currently using ironclad for two functions:

- Convert ASCII strings to octets
- Create SHA1 digests

Babel, a transient dependency, already provides this. Ironclad's only
filling need, then, is SHA1 hashing.

This change switches ironclad with the single-purpose library `sha1` to
minimize websocket-driver's footprint. It also promotes babel from a
transient to a direct dependency, in the process.

I'm currently setting this as a draft PR until the changes I've made https://github.com/massung/sha1/pull/7 which make this possible are updated in quicklisp.