### PR TITLE
fix client close-connection function

### DIFF
--- a/src/ws/base.lisp
+++ b/src/ws/base.lisp
@@ -181,8 +181,6 @@
      (emit :close ws :code code :reason reason))
     (:open
      (call-next-method))
-    (:closing
-     (emit :close ws :code code :reason reason))
     (otherwise nil)))
 
 (defgeneric open-connection (ws)


### PR DESCRIPTION
When client want to close connection, if (close (socket client)) exist, the stream is closed, the read-thread can not read.  
And the :closing case is redundance .  
wish!