### PR TITLE
Support responding to html/socket on the same uri/port.

### DIFF
--- a/examples/http-socket-server.lisp
+++ b/examples/http-socket-server.lisp
@@ -1,0 +1,28 @@
+(ql:quickload '(:websocket-driver :clack) :silent t)
+
+(in-package :cl-user)
+(defpackage websocket-test
+  (:use :cl
+        :websocket-driver))
+(in-package :websocket-test)
+
+(defun server-http-handler (env)
+  (declare (ignore env))
+  '(200 (:content-type "text/plain") ("Hello, Clack!")))
+
+(defun server-socket-handler (ws)
+  (wsd:on :message ws
+          (lambda (message)
+            (websocket-driver:send ws message)))
+  (lambda (responder)
+    (declare (ignore responder))
+    (wsd:start-connection ws)))
+
+
+(defparameter *handler* (clack:clackup  (lambda (env)
+                                          (let ((ws (wsd:make-server env)))
+                                            (if ws
+                                                (server-socket-handler ws)
+                                                (server-http-handler env))))
+                                        :server :woo
+                                        :port 5000))

--- a/examples/http-socket-server.lisp
+++ b/examples/http-socket-server.lisp
@@ -26,3 +26,13 @@
                                                 (server-http-handler env))))
                                         :server :woo
                                         :port 5000))
+
+(defparameter *client* (wsd:make-client "ws://127.0.0.1:5000"))
+
+(wsd:start-connection *client*)
+(wsd:on :message *client*
+        (lambda (message)
+          (format t "~&Got: ~A~%" message)))
+(wsd:send *client* "Hi")
+(wsd:close-connection *client*)
+(clack:stop *handler*)

--- a/src/server.lisp
+++ b/src/server.lisp
@@ -6,15 +6,24 @@
   (:export #:make-server))
 (in-package :websocket-driver.server)
 
+(defun upgrade-p (env)
+  "differntiate between html and socket requests."
+  (if (equal (getf env :request-method) :get)
+      (let ((headers (getf env :headers)))
+        (if (equal (gethash "connection" headers) "Upgrade")
+            (if (equal (gethash "upgrade" headers) "websocket")
+                t)))))
+
 (defun make-server (env &rest options &key max-length accept-protocols additional-headers)
   (declare (ignore max-length accept-protocols additional-headers))
   (let ((socket (getf env :clack.io)))
     (unless socket
       (error ":clack.io doesn't exist in ENV. Probably this server is not supported."))
-    (apply #'make-instance 'server
-           :socket socket
-           :headers (getf env :headers)
-           options)))
+    (if (upgrade-p env)
+        (apply #'make-instance 'server
+               :socket socket
+               :headers (getf env :headers)
+               options))))
 
 (import 'make-server :websocket-driver)
 (export 'make-server :websocket-driver)

--- a/src/server.lisp
+++ b/src/server.lisp
@@ -16,10 +16,10 @@
 
 (defun make-server (env &rest options &key max-length accept-protocols additional-headers)
   (declare (ignore max-length accept-protocols additional-headers))
-  (let ((socket (getf env :clack.io)))
-    (unless socket
-      (error ":clack.io doesn't exist in ENV. Probably this server is not supported."))
-    (if (upgrade-p env)
+  (if (upgrade-p env)
+      (let ((socket (getf env :clack.io)))
+        (unless socket
+          (error ":clack.io doesn't exist in ENV. Probably this server is not supported."))
         (apply #'make-instance 'server
                :socket socket
                :headers (getf env :headers)


### PR DESCRIPTION
example:
```lisp
(defun server-http-handler (env)
  (declare (ignore env))
  '(200 (:content-type "text/plain") ("Hello, Clack!")))

(defun server-socket-handler (ws)
  (wsd:on :message ws
          (lambda (message)
            (websocket-driver:send ws message)))
  (lambda (responder)
    (declare (ignore responder))
    (wsd:start-connection ws)))


(defparameter *handler* (clack:clackup  (lambda (env)
                                          (let ((ws (wsd:make-server env)))
                                            (if ws
                                                (server-socket-handler ws)
                                                (server-http-handler env))))
                                        :server :woo
                                        :port 5000))
```