### PR TITLE
Prevents infinite retry on closed streams

### DIFF
--- a/src/ws/base.lisp
+++ b/src/ws/base.lisp
@@ -206,7 +206,7 @@
       (tagbody retry
          (let ((read-bytes (handler-case 
                                (read-sequence buf stream)
-                             (error (e)
+                             (error ()
                                ;; Check if stream is still open before retrying
                                ;; If stream is closed, return nil instead of infinite retry
                                (cond

--- a/src/ws/base.lisp
+++ b/src/ws/base.lisp
@@ -204,10 +204,19 @@
         (extended-buf (make-array 8 :element-type '(unsigned-byte 8))))
     (block nil
       (tagbody retry
-         (let ((read-bytes (handler-case (read-sequence buf stream)
-                             (error ()
-                               ;; Retry when I/O timeout error
-                               (go retry)))))
+         (let ((read-bytes (handler-case 
+                               (read-sequence buf stream)
+                             (error (e)
+                               ;; Check if stream is still open before retrying
+                               ;; If stream is closed, return nil instead of infinite retry
+                               (cond
+                                 ((not (open-stream-p stream))
+                                  ;; Stream closed - stop reading
+                                  (return nil))
+                                 (t
+                                  ;; I/O timeout or other transient error - retry
+                                  (declare (ignore e))
+                                  (go retry)))))))
            (when (= read-bytes 0)
              (return nil))
 

--- a/src/ws/base.lisp
+++ b/src/ws/base.lisp
@@ -215,7 +215,6 @@
                                   (return nil))
                                  (t
                                   ;; I/O timeout or other transient error - retry
-                                  (declare (ignore e))
                                   (go retry)))))))
            (when (= read-bytes 0)
              (return nil))


### PR DESCRIPTION
Modifies the read sequence retry logic to check if the stream is still open. This prevents infinite retries when the stream has been closed, instead returning nil. This avoids potential deadlocks.

This should fix #49 I'm still testing this but I wanted to put this out for review in the meantime.