### PR TITLE
Fixed two thread-related memory corruption problems

### DIFF
--- a/src/ws/client.lisp
+++ b/src/ws/client.lisp
@@ -171,7 +171,7 @@
                                                                               (uiop:native-namestring ca-path)
                                                                               :default))))
                            ;; TODO: certificate files
-                           (cl+ssl:with-global-context (ctx :auto-free-p t)
+                           (cl+ssl:with-global-context (ctx)
                              (cl+ssl:make-ssl-client-stream stream
                                                             :hostname (uri-host uri)
                                                             :verify (if verify :optional nil)))))
@@ -188,6 +188,7 @@
 		    (loop for frame = (read-websocket-frame stream)
                           while frame
                           do (parse client frame))
+                 ;; When close-connection kills this thread the unwind-protect may be called again.
                  (close-connection client)))
              :name "websocket client read thread"
              :initial-bindings `((*standard-output* . ,*standard-output*)
@@ -265,14 +266,15 @@
       (funcall callback))))
 
 (defmethod close-connection ((client client) &optional reason code)
-  (ignore-errors (close (socket client)))
-  (setf (ready-state client) :closed)
-  (let ((thread (read-thread client)))
-    (when thread
-      (if (and (bt2::threadp thread)
-	       (bt2::thread-alive-p thread)
-	       (not (eq (bt2:current-thread) thread)))
-	  (bt2::destroy-thread thread))
-      (setf (read-thread client) nil)))
-  (emit :close client :code code :reason reason)
-  t)
+  (unless (eq (ready-state client) :closed)
+    (ignore-errors (close (socket client)))
+    (setf (ready-state client) :closed)
+    (let ((thread (read-thread client)))
+      (when thread
+        (if (and (bt2::threadp thread)
+	         (bt2::thread-alive-p thread)
+	         (not (eq (bt2:current-thread) thread)))
+	    (bt2::destroy-thread thread))
+        (setf (read-thread client) nil)))
+    (emit :close client :code code :reason reason)
+    t))


### PR DESCRIPTION
1. `cl+ssl:with-global-context` shouldn't use auto-free because if multiple clients are alive in different threads, a client's closing the lisp stream (somehow) leads to other clients' read thread accessing a null pointer on C side, presumably the context object. The memory corruption is only seen in SBCL/Allegro+Debian+AWS but cannot be reproduced in SBCL/Allegro/CCL+FreeBSD+my own PC, reproducible by writing a for loop to close about 10 very chatty web socket clients. Although AI says there's reference counting on libssl's side, removing the auto-free option indeed makes the said for loop run correctly.

2. When close-connection is called, it kills the reader thread. But the reader thread has a unwind-protect that executes yet another close-connection; this leads to `(close (socket client))` being called twice. Guarding against this (plus the previous said auto-free problem) has eliminated all memory corruption problem in my system when run on SBCL+Linux. Looking at cl+ssl I cannot find safe-guarding code, so maybe the close call goes directly to the dynamic library. Also it's unclear to me whether all implementations will execute unwind-protect cleaners when thread is killed. At least SBCL and CCL on both FreeBSD and Linux do execute that---I haven't tested more others, hence the ugly hacky guard.

LIMITATION:
Now that after this patch there's no auto-free so we have a memory leak of one SSL context. I'm not familiar enough with SSL to judge what to do with the global context, especially when other libraries may use cl+ssl as well, but now at least no more memory corruptions. It's up to you to decide what to do if you want it perfect; the code in this commit is for your reference.